### PR TITLE
Satzzeichen hinter der Grußformel entfernt 

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -238,7 +238,7 @@ Ich nehme zur Kenntnis, dass es sich bei der Demonstration nicht um eine Schulve
 Ich bitte darum, unter diesen besonderen Umständen von einer Eintragung unentschuldigter Fehlstunden abzusehen.
 
 
-Mit freundlichen Grüßen,
+Mit freundlichen Grüßen
 
 ${namefrom}
 


### PR DESCRIPTION
Satzzeichen bei der Grußformel entfernt (vgl. https://www.duden.de/sprachwissen/sprachratgeber/Die-Gru%C3%9Fformel-in-Brief-und-E-Mail)